### PR TITLE
Update with mcuboot middleware info

### DIFF
--- a/mtb-mw-manifest.xml
+++ b/mtb-mw-manifest.xml
@@ -994,4 +994,17 @@
       </version>
     </versions>
   </middleware>
+  <middleware>
+    <name>mcuboot</name>
+    <id>mcuboot</id>
+    <uri>https://github.com/JuulLabs-OSS/mcuboot.git</uri>
+    <desc>MCUboot is a bootloader for 32-bit MCUs, used as part of OTA support.</desc>
+    <versions>
+      <version flow_version="1.0,2.0">
+        <commit>v1.5.0-cypress</commit>
+        <num>v1.5.0-cypress</num>
+        <desc>MCUBoot for Cypress v1.5.0</desc>
+        </version>
+    </versions>
+  </middleware>
 </middleware>


### PR DESCRIPTION
Needed middleware entry for mcuboot

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/cypresssemiconductorco/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Update manifest to include mcuboot middleware info.
Needed to resolve MIDDLEWARE-3934.
